### PR TITLE
Friends dont let friends use os.listdir

### DIFF
--- a/apps_validation/scripts/catalog_update.py
+++ b/apps_validation/scripts/catalog_update.py
@@ -111,8 +111,8 @@ def publish_updated_apps(catalog_path: str) -> None:
                 shutil.move(values_path, ix_values_path)
 
             for version in pathlib.Path(publish_app_path).iterdir():
-                if all((
-                    version.is_dir(),
+                if any((
+                    not version.is_dir(),
                     version.name in required_versions
                 )):
                     continue

--- a/apps_validation/scripts/catalog_update.py
+++ b/apps_validation/scripts/catalog_update.py
@@ -1,7 +1,7 @@
 import argparse
+import pathlib
 import contextlib
 import json
-import pathlib
 import os
 import shutil
 import typing
@@ -110,13 +110,15 @@ def publish_updated_apps(catalog_path: str) -> None:
             if not os.path.exists(ix_values_path) and os.path.exists(values_path):
                 shutil.move(values_path, ix_values_path)
 
-            for version in os.listdir(publish_app_path):
-                version_path = os.path.join(publish_app_path, version)
-                if not os.path.isdir(version_path) or version in required_versions:
+            for version in pathlib.Path(publish_app_path).iterdir():
+                if all((
+                    version.is_dir(),
+                    version.name in required_versions
+                )):
                     continue
 
-                if version != app_version:
-                    shutil.rmtree(version_path)
+                if version.name != app_version:
+                    shutil.rmtree(version.as_posix())
 
             print(
                 f'[\033[92mOK\x1B[0m]\tPublished {app_name!r} having {app_version!r} version '

--- a/apps_validation/scripts/catalog_update.py
+++ b/apps_validation/scripts/catalog_update.py
@@ -1,6 +1,7 @@
 import argparse
 import contextlib
 import json
+import pathlib
 import os
 import shutil
 import typing
@@ -65,17 +66,11 @@ def validate_versions_data(versions_data):
 def get_apps_to_publish(catalog_path: str) -> dict:
     ci_dev_dir = get_ci_development_directory(catalog_path)
     to_publish_apps = defaultdict(list)
-    for train_name in os.listdir(ci_dev_dir):
-        train_path = os.path.join(ci_dev_dir, train_name)
-        if not os.path.isdir(train_path):
-            continue
-
-        for app_name in os.listdir(train_path):
-            app_path = os.path.join(train_path, app_name)
-            if not os.path.isdir(app_path):
-                continue
-
-            app_current_version = get_app_version(app_path)
+    for train_path in filter(lambda x: x.is_dir(), pathlib.Path(ci_dev_dir).iterdir()):
+        train_name = train_path.name
+        for app_path in filter(lambda x: x.is_dir(), train_path.iterdir()):
+            app_name = app_path.name
+            app_current_version = get_app_version(app_path.as_posix())
             if version_has_been_bumped(os.path.join(catalog_path, train_name, app_name), app_current_version):
                 to_publish_apps[train_name].append({'name': app_name, 'version': app_current_version})
 

--- a/apps_validation/validation/validate_app_rename_migrations.py
+++ b/apps_validation/validation/validate_app_rename_migrations.py
@@ -1,41 +1,30 @@
 import json
+import pathlib
+
 import jsonschema
-import os
-import re
 
 from apps_validation.exceptions import ValidationErrors
 
 from .json_schema_utils import APP_MIGRATION_SCHEMA
 
 
-MIGRATION_NAME_STR = r'^\d+\w+.json'
-RE_MIGRATION_NAME = re.compile(MIGRATION_NAME_STR)
-
-
 def validate_migrations(migration_dir: str):
     verrors = ValidationErrors()
-    if not os.path.exists(migration_dir):
+    suffix = '.json'
+    try:
+        for migration_file in filter(lambda x: x.is_file(), pathlib.Path(migration_dir).iterdir()):
+            schema_str = f'app_migrations.{migration_file.name}'
+            if migration_file.suffix != suffix:
+                verrors.add(schema_str, f'File suffix must be {suffix}')
+            elif not migration_file[0].isdigit():
+                verrors.add(schema_str, 'File must start with a digit')
+            else:
+                jsonschema.validate(json.loads(migration_file.read_text()), APP_MIGRATION_SCHEMA)
+    except FileNotFoundError:
         return
-
-    if not os.path.isdir(migration_dir):
+    except NotADirectoryError:
         verrors.add('app_migrations', f'{migration_dir!r} must be a directory')
-        verrors.check()
+    except (json.JSONDecodeError, jsonschema.ValidationError) as e:
+        verrors.add(f'app_migrations.{migration_file}', f'Failed to validate migration file structure: {e}')
 
-    for migration_file in os.listdir(migration_dir):
-        if not RE_MIGRATION_NAME.findall(migration_file):
-            verrors.add(
-                f'app_migrations.{migration_file}',
-                'Invalid naming scheme used for migration file name. '
-                f'It should be conforming to {MIGRATION_NAME_STR!r} pattern.'
-            )
-        else:
-            try:
-                with open(os.path.join(migration_dir, migration_file), 'r') as f:
-                    data = json.loads(f.read())
-                jsonschema.validate(data, APP_MIGRATION_SCHEMA)
-            except (json.JSONDecodeError, jsonschema.ValidationError) as e:
-                verrors.add(
-                    f'app_migrations.{migration_file}',
-                    f'Failed to validate migration file structure: {e}'
-                )
     verrors.check()

--- a/apps_validation/validation/validate_dev_directory.py
+++ b/apps_validation/validation/validate_dev_directory.py
@@ -45,7 +45,7 @@ def validate_train(catalog_path: str, train_path: str, schema: str, to_check_app
         else:
             published_train_app_path = os.path.join(catalog_path, train_name, app_name)
             try:
-                if not version_has_been_bumped(published_train_app_path, get_app_version(app_path)):
+                if not version_has_been_bumped(published_train_app_path, get_app_version(app_path.name)):
                     verrors.add(
                         f'{schema}.{app_name}.version',
                         'Version must be bumped as app has been changed but version has not been updated'

--- a/apps_validation/validation/validate_dev_directory.py
+++ b/apps_validation/validation/validate_dev_directory.py
@@ -1,6 +1,7 @@
+import pathlib
 import os
-import yaml
 
+import yaml
 from jsonschema import ValidationError as JsonValidationError
 
 from apps_validation.exceptions import ValidationErrors
@@ -16,53 +17,53 @@ from .validate_app_version import validate_catalog_item_version
 
 def validate_dev_directory_structure(catalog_path: str, to_check_apps: dict) -> None:
     verrors = ValidationErrors()
-    dev_directory = get_ci_development_directory(catalog_path)
-    if not os.path.exists(dev_directory):
+    try:
+        for i in pathlib.Path(get_ci_development_directory(catalog_path)).iterdir():
+            if i.is_dir() and i.name in to_check_apps:
+                validate_train(catalog_path, i.as_posix(), f'dev.{i.name}', to_check_apps[i.name])
+    except (FileNotFoundError, NotADirectoryError):
         return
 
-    for train_name in filter(
-        lambda name: name in to_check_apps and os.path.isdir(os.path.join(dev_directory, name)),
-        os.listdir(dev_directory)
-    ):
-        validate_train(
-            catalog_path, os.path.join(dev_directory, train_name), f'dev.{train_name}', to_check_apps[train_name]
-        )
     verrors.check()
 
 
 def validate_train(catalog_path: str, train_path: str, schema: str, to_check_apps: list) -> None:
     verrors = ValidationErrors()
     train_name = os.path.basename(train_path)
-    for app_name in filter(
-        lambda name: os.path.isdir(os.path.join(train_path, name)), os.listdir(train_path)
-    ):
+    for app_path in pathlib.Path(train_path).iterdir():
+        if not app_path.is_dir():
+            continue
+
+        app_name = app_path.name
         if app_name not in to_check_apps:
             continue
 
-        app_path = os.path.join(train_path, app_name)
         try:
-            validate_app(app_path, f'{schema}.{app_name}', train_name)
+            validate_app(app_path.as_posix(), f'{schema}.{app_name}', train_name)
         except ValidationErrors as ve:
             verrors.extend(ve)
         else:
             published_train_app_path = os.path.join(catalog_path, train_name, app_name)
-            if not os.path.exists(published_train_app_path):
+            try:
+                if not version_has_been_bumped(published_train_app_path, get_app_version(app_path)):
+                    verrors.add(
+                        f'{schema}.{app_name}.version',
+                        'Version must be bumped as app has been changed but version has not been updated'
+                    )
+            except FileNotFoundError:
                 # The application is new and we are good
                 continue
-
-            if not version_has_been_bumped(published_train_app_path, get_app_version(app_path)):
-                verrors.add(
-                    f'{schema}.{app_name}.version',
-                    'Version must be bumped as app has been changed but version has not been updated'
-                )
 
         verrors.check()
 
 
 def validate_upgrade_strategy(app_path: str, schema: str, verrors: ValidationErrors):
     upgrade_strategy_path = os.path.join(app_path, UPGRADE_STRATEGY_FILENAME)
-    if os.path.exists(upgrade_strategy_path) and not os.access(upgrade_strategy_path, os.X_OK):
-        verrors.add(schema, f'{upgrade_strategy_path!r} is not executable')
+    try:
+        if not os.access(upgrade_strategy_path, os.X_OK):
+            verrors.add(schema, f'{upgrade_strategy_path!r} is not executable')
+    except FileNotFoundError:
+        pass
 
 
 def validate_app(app_dir_path: str, schema: str, train_name: str) -> None:
@@ -76,14 +77,19 @@ def validate_app(app_dir_path: str, schema: str, train_name: str) -> None:
         app_dir_path, schema, get_app_version(app_dir_path), app_name, True, train_name=train_name,
     )
 
-    required_files = set(REQUIRED_METADATA_FILES)
-    available_files = set(
-        f for f in filter(lambda f: os.path.isfile(os.path.join(app_dir_path, f)), os.listdir(app_dir_path))
-    )
-    if missing_files := required_files - available_files:
+    # TODO: Stop using globally defined mutable objects
+    total_num_of_required_files = len(REQUIRED_METADATA_FILES)
+    total_num_of_required_files_found = 0
+    for i in pathlib.Path(app_dir_path).iterdir():
+        if total_num_of_required_files_found == total_num_of_required_files:
+            break
+        elif i.is_file() and i.name in REQUIRED_METADATA_FILES:
+            total_num_of_required_files_found += 1
+
+    if total_num_of_required_files_found != total_num_of_required_files:
         verrors.add(
             f'{schema}.required_files',
-            f'{", ".join(missing_files)!r} file(s) must be specified'
+            f'All of the following files must exist: {", ".join(REQUIRED_METADATA_FILES)!r}'
         )
     validate_upgrade_strategy(app_dir_path, f'{schema}.{UPGRADE_STRATEGY_FILENAME}', verrors)
     verrors.check()

--- a/apps_validation/validation/validate_train.py
+++ b/apps_validation/validation/validate_train.py
@@ -1,4 +1,5 @@
 import os
+import pathlib
 import typing
 
 from apps_validation.exceptions import ValidationErrors
@@ -17,10 +18,13 @@ def validate_train_structure(train_path: str, schema: str):
 
 def get_train_items(train_path: str) -> typing.List[typing.Tuple[str, str]]:
     train = os.path.basename(train_path)
-    items = []
-    for catalog_item in os.listdir(train_path):
-        item_path = os.path.join(train_path, catalog_item)
-        if not os.path.isdir(item_path):
-            continue
-        items.append((item_path, f'trains.{train}.{catalog_item}', train))
-    return items
+    # TODO: do we really need to iterate over every file in `train_paths`??
+    # what happens if this directory stores a ton of files? Seems like
+    # we could do this differently
+    return [
+        (
+            i.as_posix(),  # full path
+            f'trains.{train}.{i.name}',
+            train,
+        ) for i in filter(lambda x: x.is_dir(), pathlib.Path(train_path).iterdir())
+    ]

--- a/catalog_reader/app.py
+++ b/catalog_reader/app.py
@@ -108,6 +108,11 @@ def get_app_details_impl(
 
     item_data.update({k: item_data.get(k) for k in ITEM_KEYS})
 
+    # FIXME: listing the entire contents of item_path just for the
+    # situation where `retrieve_latest_version` is True. We're not
+    # actually gaining anything by doing this because we're still
+    # enumerating the entire contents of item_path into a list
+    # We should consider redesigning this.
     for version in sorted(
         filter(lambda p: os.path.isdir(os.path.join(item_path, p)), os.listdir(item_path)),
         reverse=True, key=parse_version,

--- a/catalog_reader/app.py
+++ b/catalog_reader/app.py
@@ -109,10 +109,10 @@ def get_app_details_impl(
     item_data.update({k: item_data.get(k) for k in ITEM_KEYS})
 
     # FIXME: listing the entire contents of item_path just for the
-    # situation where `retrieve_latest_version` is True. We're not
-    # actually gaining anything by doing this because we're still
-    # enumerating the entire contents of item_path into a list
-    # We should consider redesigning this.
+    # situation where `retrieve_latest_version` is True is flawed.
+    # We're not actually gaining anything by doing this because
+    # we're still enumerating the entire contents of item_path
+    # into a list. We should consider redesigning this.
     for version in sorted(
         filter(lambda p: os.path.isdir(os.path.join(item_path, p)), os.listdir(item_path)),
         reverse=True, key=parse_version,

--- a/catalog_reader/catalog.py
+++ b/catalog_reader/catalog.py
@@ -1,6 +1,7 @@
 import concurrent.futures
 import functools
 import os
+import pathlib
 import typing
 
 from .app import get_app_details
@@ -21,7 +22,7 @@ def retrieve_train_names(location: str, all_trains=True, trains_filter=None) -> 
     for train in pathlib.Path(location).iterdir():
         if any((
             not (all_trains or train.name in trains_filter),
-            not is_train_valid(train.name, train.as_posix()):
+            not is_train_valid(train.name, train.as_posix()),
         )):
             continue
         else:

--- a/catalog_reader/catalog.py
+++ b/catalog_reader/catalog.py
@@ -18,20 +18,23 @@ def app_details(apps: dict, location: str, questions_context: typing.Optional[di
 def retrieve_train_names(location: str, all_trains=True, trains_filter=None) -> list:
     train_names = []
     trains_filter = trains_filter or []
-    for train in os.listdir(location):
-        if not (all_trains or train in trains_filter) or not is_train_valid(train, os.path.join(location, train)):
+    for train in pathlib.Path(location).iterdir():
+        if any((
+            not (all_trains or train.name in trains_filter),
+            not is_train_valid(train.name, train.as_posix()):
+        )):
             continue
-        train_names.append(train)
+        else:
+            train_names.append(train.name)
     return train_names
 
 
 def get_apps_in_trains(trains_to_traverse: list, catalog_location: str) -> dict:
     items = {}
     for train in trains_to_traverse:
-        items.update({
-            f'{i}_{train}': train for i in os.listdir(os.path.join(get_train_path(catalog_location), train))
-            if os.path.isdir(os.path.join(get_train_path(catalog_location), train, i))
-        })
+        train_path = os.path.join(get_train_path(catalog_location), train)
+        for i in filter(lambda x: x.is_dir(), pathlib.Path(train_path).iterdir()):
+            items.update({f'{i.name}_{train}': i.as_posix()})
 
     return items
 

--- a/catalog_reader/dev_directory.py
+++ b/catalog_reader/dev_directory.py
@@ -1,6 +1,7 @@
 import os
-import yaml
+import pathlib
 
+import yaml
 from jsonschema import validate as json_schema_validate
 from semantic_version import Version
 
@@ -30,14 +31,15 @@ def get_ci_development_directory(catalog_path: str) -> str:
 
 
 def version_has_been_bumped(app_path: str, new_version: str) -> bool:
-    if not os.path.isdir(app_path):
+    versions = list()
+    try:
+        for version in filter(lambda x: x.is_dir(), pathlib.Path(app_path).iterdir()):
+            versions.append(Version(version.name))
+        versions.sort()
+        return not versions or Version(new_version) > versions[-1]
+    except (FileNotFoundError, NotADirectoryError):
+        # why return a different type and not just an empty list?
         return True
-
-    versions = [
-        Version(version) for version in filter(lambda v: os.path.isdir(os.path.join(app_path, v)), os.listdir(app_path))
-    ]
-    versions.sort()
-    return not versions or Version(new_version) > versions[-1]
 
 
 def get_to_keep_versions(app_dir_path: str) -> list:


### PR DESCRIPTION
There are some serious design issues through this library. I'm fully aware that there shouldn't be a "large" amount of files/directories that we iterate over but we're still using an unnecessary amount of memory in this library.

In 99.9999% of all scenarios, os.listdir is never the right function to call. It generates a list of the entire contents of the path that you provide. os.scandir or, my preference, pathlib.Path.iterdir should be used instead. This changes all callers of os.listdir to pathlib.Path.iterdir with the exception of 1. I made a comment about that one so that someone can come back and revisit designing it appropriately.

While I was here, I made some improvements so that we don't call os.listdir (which gives us a list of everything) just to make our own list of files/dirs to be returned (so doubling the amount of memory we use). I've sacrificed some nice(er) error messages about missing files on the justification of being more memory efficient.