### PR TITLE
move values under "values" key

### DIFF
--- a/catalog_templating/render.py
+++ b/catalog_templating/render.py
@@ -33,7 +33,7 @@ def render_templates(app_version_path: str, test_values: dict) -> dict:
         # env.filters['make_capital'] = lambda st: st.upper()
         rendered_templates[to_render_file.name] = env.get_template(
             to_render_file.name
-        ).render(test_values | {'ix_lib': template_libs})
+        ).render({'ix_lib': template_libs, 'values': test_values})
 
     return rendered_templates
 


### PR DESCRIPTION
Idea is to have all values coming from the user under one key.
This makes it easier to pass the whole context to a function for validation, normalization or other processing.

In addition makes it easier to "dump" the data while developing in order to see the contents.

This should allow later to pass extra keys without risking overriding any user values.
eg ix_app_context, etc.
To be fair, I don't expect this to be the case.

PS. Is this function going to be used in production too? If not, we should also adapt the production side as-well.
