### PR TITLE
NAS-129729 / 24.10 / Do not error out if no app is to be published

### DIFF
--- a/apps_ci/scripts/catalog_update.py
+++ b/apps_ci/scripts/catalog_update.py
@@ -103,6 +103,9 @@ def publish_updated_apps(catalog_path: str) -> None:
 
             dev_item_yaml_path = os.path.join(dev_app_path, 'item.yaml')
             publish_item_yaml_path = os.path.join(publish_app_path, 'item.yaml')
+            if os.path.exists(publish_app_version_path):
+                continue
+
             shutil.copy(dev_item_yaml_path, publish_item_yaml_path)
             shutil.copytree(dev_app_path, publish_app_version_path)
 


### PR DESCRIPTION
## Problem

We have a publish action whose usecase is to publish any apps which have been updated in our dev workflow for apps. However if no app update has been made and we attempt to publish it errors out saying relevant version already exists. This should be a safe operation.

## Solution

If a version has been published already, let's not attempt to do that again hence making the publish action safe to use in the CI.