### PR TITLE
update casing on variable names

### DIFF
--- a/apps_schema/features/ix_volume.py
+++ b/apps_schema/features/ix_volume.py
@@ -13,13 +13,13 @@ class IXVolumeFeature(BaseFeature):
             return
 
         attrs = schema_obj.attrs
-        if 'datasetName' not in attrs:
-            verrors.add(f'{schema_str}.attrs', 'Variable "datasetName" must be specified.')
-        elif not isinstance(attrs[attrs.index('datasetName')].schema, StringSchema):
-            verrors.add(f'{schema_str}.attrs', 'Variable "datasetName" must be of string type.')
+        if 'dataset_name' not in attrs:
+            verrors.add(f'{schema_str}.attrs', 'Variable "dataset_name" must be specified.')
+        elif not isinstance(attrs[attrs.index('dataset_name')].schema, StringSchema):
+            verrors.add(f'{schema_str}.attrs', 'Variable "dataset_name" must be of string type.')
 
-        if 'aclEntries' in attrs and not isinstance(attrs[attrs.index('aclEntries')].schema, DictSchema):
-            verrors.add(f'{schema_str}.attrs', 'Variable "aclEntries" must be of dict type.')
+        if 'acl_entries' in attrs and not isinstance(attrs[attrs.index('acl_entries')].schema, DictSchema):
+            verrors.add(f'{schema_str}.attrs', 'Variable "acl_entries" must be of dict type.')
 
         if 'properties' in attrs:
             index = attrs.index('properties')

--- a/catalog_reader/questions.py
+++ b/catalog_reader/questions.py
@@ -83,10 +83,10 @@ def normalize_question(question: dict, version_data: dict, context: dict) -> Non
         elif ref == 'normalize/acl':
             data['attrs'] = ACL_QUESTION
         elif ref == 'normalize/ixVolume':
-            if schema['type'] == 'dict' and any(i['variable'] == 'aclEntries' for i in schema['attrs']):
-                # get index of aclEntries from attrs
-                acl_index = next(i for i, v in enumerate(schema['attrs']) if v['variable'] == 'aclEntries')
-                # insert acl question before aclEntries
+            if schema['type'] == 'dict' and any(i['variable'] == 'acl_entries' for i in schema['attrs']):
+                # get index of acl_entries from attrs
+                acl_index = next(i for i, v in enumerate(schema['attrs']) if v['variable'] == 'acl_entries')
+                # insert acl question before acl_entries
                 schema['attrs'][acl_index]['schema']['attrs'] = IX_VOLUMES_ACL_QUESTION
 
     schema.update(data)

--- a/catalog_reader/questions_util.py
+++ b/catalog_reader/questions_util.py
@@ -16,7 +16,7 @@ ACL_QUESTION = [
         'schema': {
             'type': 'list',
             'items': [{
-                'variable': 'aclEntry',
+                'variable': 'acl_entry',
                 'label': 'ACL Entry',
                 'schema': {
                     'type': 'dict',


### PR DESCRIPTION
Updates casing on variable names to keep everything consistent.

We probably also update the `$ref`s (eg `normalize/ixVolume` to `normalize/ix_volume`)