### PR TITLE
NAS-129962 / 24.10 / Include version key when retrieving app details

### DIFF
--- a/catalog_reader/app.py
+++ b/catalog_reader/app.py
@@ -171,6 +171,9 @@ def get_app_version_details(
 
     app_metadata = version_data['app_metadata']
     # TODO: See if this needs to change for our adaptation of ix-chart
-    version_data['human_version'] = get_human_version(app_metadata['app_version'], app_metadata['version'])
+    version_data.update({
+        'human_version': get_human_version(app_metadata['app_version'], app_metadata['version']),
+        'version': app_metadata['version'],
+    })
 
     return version_data


### PR DESCRIPTION
This commit adds changes to include version key when retrieving app details with human version to make it easy when management tasks are being performed on apps like app upgrade/rollback etc