### PR TITLE
NAS-130046 / 24.10 / Fix apps schema features casing

### DIFF
--- a/apps_schema/features/basic.py
+++ b/apps_schema/features/basic.py
@@ -5,7 +5,7 @@ from .base import BaseFeature
 
 class DefinitionGPUConfigurationFeature(BaseFeature):
 
-    NAME = 'definitions/gpuConfiguration'
+    NAME = 'definitions/gpu_configuration'
     VALID_SCHEMAS = [DictSchema]
 
 

--- a/apps_schema/features/certificate.py
+++ b/apps_schema/features/certificate.py
@@ -11,5 +11,5 @@ class CertificateFeature(BaseFeature):
 
 class CertificateAuthorityFeature(BaseFeature):
 
-    NAME = 'definitions/certificateAuthority'
+    NAME = 'definitions/certificate_authority'
     VALID_SCHEMAS = [IntegerSchema]

--- a/apps_schema/features/container_image.py
+++ b/apps_schema/features/container_image.py
@@ -5,7 +5,7 @@ from .base import BaseFeature
 
 class ContainerImageFeature(BaseFeature):
 
-    NAME = 'validations/containerImage'
+    NAME = 'validations/container_image'
     VALID_SCHEMAS = [DictSchema]
 
     def _validate(self, verrors, schema_obj, schema_str):

--- a/apps_schema/features/interface.py
+++ b/apps_schema/features/interface.py
@@ -4,7 +4,7 @@ from .base import BaseFeature
 
 
 class NormalizeInterfaceConfiguration(BaseFeature):
-    NAME = 'normalize/interfaceConfiguration'
+    NAME = 'normalize/interface_configuration'
     VALID_SCHEMAS = [DictSchema]
 
 

--- a/apps_schema/features/node.py
+++ b/apps_schema/features/node.py
@@ -5,11 +5,11 @@ from .base import BaseFeature
 
 class DefinitionNodeIPFeature(BaseFeature):
 
-    NAME = 'definitions/nodeIP'
+    NAME = 'definitions/node_ip'
     VALID_SCHEMAS = [StringSchema]
 
 
 class ValidationNodePortFeature(BaseFeature):
 
-    NAME = 'validations/nodePort'
+    NAME = 'validations/node_port'
     VALID_SCHEMAS = [IntegerSchema]


### PR DESCRIPTION
## Context

As we have moved over to docker and python - we are updating casing in the features definition so that they can be used instead of the camelcase we had in place reflecting golang/helm's primary casing preference.