### PR TITLE
NAS-130170 / 24.10 / Fix node_ip feature

### DIFF
--- a/apps_schema/features/node.py
+++ b/apps_schema/features/node.py
@@ -1,15 +1,9 @@
-from apps_schema.attrs import IntegerSchema, StringSchema
+from apps_schema.attrs import StringSchema
 
 from .base import BaseFeature
 
 
 class DefinitionNodeIPFeature(BaseFeature):
 
-    NAME = 'definitions/node_ip'
+    NAME = 'definitions/node_bind_ip'
     VALID_SCHEMAS = [StringSchema]
-
-
-class ValidationNodePortFeature(BaseFeature):
-
-    NAME = 'validations/node_port'
-    VALID_SCHEMAS = [IntegerSchema]

--- a/catalog_reader/app_utils.py
+++ b/catalog_reader/app_utils.py
@@ -31,10 +31,9 @@ def get_app_details_base(retrieve_complete_item_keys: bool = True) -> dict:
 
 def get_default_questions_context() -> dict:
     return {
-        'nic_choices': [],
         'gpus': {},
         'timezones': {'Asia/Saigon': 'Asia/Saigon', 'Asia/Damascus': 'Asia/Damascus'},
-        'node_ip': '192.168.0.10',
+        'ip_choices': {'192.168.0.10': '192.168.0.10', '0.0.0.0': '0.0.0.0'},
         'certificates': [],
         'certificate_authorities': [],
         'system.general.config': {'timezone': 'America/Los_Angeles'},

--- a/catalog_reader/questions.py
+++ b/catalog_reader/questions.py
@@ -57,8 +57,11 @@ def normalize_question(question: dict, version_data: dict, context: dict) -> Non
                 'enum': [{'value': t, 'description': f'{t!r} timezone'} for t in sorted(context['timezones'])],
                 'default': context['system.general.config']['timezone']
             })
-        elif ref == 'definitions/nodeIP':
-            data['default'] = context['node_ip']
+        elif ref == 'definitions/node_bind_ip':
+            data.update({
+                'default': '0.0.0.0',
+                'enum': [{'value': i, 'description': f'{i!r} IP Address'} for i in context['ip_choices']],
+            })
         elif ref == 'definitions/certificate':
             get_cert_ca_options(schema, data, {'value': None, 'description': 'No Certificate'})
             data['enum'] += [


### PR DESCRIPTION
## Context

Remove `validations/node_port` feature as it's not being used anymore and `definitions/port` already automatically enforces that unused ports get consumed.

Adjust node ip ref to actually show all the ips available on the host which the app can bind to.