### PR TITLE
NAS-130171 / 24.10 / Allow force flag for ACLs being applied on ix volumes

### DIFF
--- a/catalog_reader/questions_util.py
+++ b/catalog_reader/questions_util.py
@@ -91,7 +91,26 @@ IX_VOLUMES_ACL_QUESTION = [
             'hidden': True
         }
     },
-    ACL_QUESTION[1]
+    ACL_QUESTION[1],
+    {
+        'variable': 'options',
+        'label': 'ACL Options',
+        'schema': {
+            'type': 'dict',
+            'hidden': True,
+            'attrs': [
+                {
+                    'variable': 'force',
+                    'label': 'Force Flag',
+                    'description': 'Enabling `Force` applies ACL even if the path has existing data',
+                    'schema': {
+                        'type': 'boolean',
+                        'default': True,
+                    }
+                },
+            ],
+        },
+    },
 ]
 
 


### PR DESCRIPTION
## Context

For ix volumes, expose a force flag which will allow to apply ACLs even if the path has existing data - this would be useful for the case if ACLs are changed for a path later on and the ix volume in question already has data inside.