### PR TITLE
truncate unused_ports to reduce the size of app_versions.json

### DIFF
--- a/catalog_reader/catalog.py
+++ b/catalog_reader/catalog.py
@@ -41,6 +41,8 @@ def retrieve_trains_data(
     trains_to_traverse: list, job: typing.Any = None, questions_context: typing.Optional[dict] = None
 ) -> typing.Tuple[dict, set]:
     questions_context = questions_context or get_default_questions_context()
+    # Truncate unused_ports to reduce the size of app_versions.json
+    questions_context['unused_ports'] = questions_context['unused_ports'][:3]
     trains = {
         'stable': {},
         **{k: {} for k in trains_to_traverse},


### PR DESCRIPTION
The generated app_versions.json file is HUGE due to the unused ports.
Considering the values are generated on the fly each time, I _think_ the app_versions.json does not need to list all the ports, just 1 or 2 or 3. or maybe 0?

https://raw.githubusercontent.com/truenas/apps/09c9e5f1205127b475a023290a8e266c1361a5e4/trains/charts/plex/app_versions.json

I'm not sure if this is the right place to manipulate this. Feel free to update or make a new PR!