### PR TITLE
NAS-130323 / 24.10 / Make sure ix_values.yaml file is provided to compose rendering if it exists

### DIFF
--- a/catalog_templating/scripts/render_compose.py
+++ b/catalog_templating/scripts/render_compose.py
@@ -16,7 +16,9 @@ def render_templates_from_path(app_path: str, values_file: str) -> None:
 
     verrors.check()
 
-    rendered_data = render_templates(app_path, get_values(values_file))
+    rendered_data = render_templates(
+        app_path, get_values(values_file) | get_values(os.path.join(app_path, 'ix_values.yaml'))
+    )
     write_template_yaml(app_path, rendered_data)
 
 


### PR DESCRIPTION
## Context

It would be nice if we can have some values constant and not specified in questions.yaml i.e image values. This is similar to what we had with `ix_values.yaml` in k8s implementation, after discussing with Stavros that change has been made here as well so we can have such values separately and added when we render compose file.