### PR TITLE
fix validation

### DIFF
--- a/apps_validation/validate_templates.py
+++ b/apps_validation/validate_templates.py
@@ -61,7 +61,9 @@ def validate_template_rendering(app_path: str, schema: str, verrors: ValidationE
     for test_values_file in test_values_files:
         try:
             rendered = render_templates(
-                app_path, get_values(os.path.join(get_test_values_dir_path(app_path), test_values_file))
+                app_path, get_values(os.path.join(get_test_values_dir_path(app_path), test_values_file)) | get_values(
+                    os.path.join(app_path, 'ix_values.yaml')
+                )
             )
         except Exception as e:
             verrors.add(schema, f'Failed to render templates using {test_values_file!r}: {e}')


### PR DESCRIPTION
Using `ix_values.yaml` works for render, but seems to fail validations
https://github.com/truenas/apps/actions/runs/10166994937/job/28118569064

I think we are not loading the values during the validation.

More context:
https://github.com/truenas/apps_validation/pull/38