### PR TITLE
NAS-130223 / 24.10 / Don't normalize apps versions data while caching

### DIFF
--- a/apps_ci/scripts/catalog_update.py
+++ b/apps_ci/scripts/catalog_update.py
@@ -26,7 +26,8 @@ def get_trains(location: str) -> typing.Tuple[dict, dict]:
     catalog_data = {}
     versions_data = {}
     for train_name, train_data in retrieve_trains_data(
-        get_apps_in_trains(trains_to_traverse, location), location, preferred_trains, trains_to_traverse
+        get_apps_in_trains(trains_to_traverse, location), location, preferred_trains, trains_to_traverse,
+        normalize_questions=False,
     )[0].items():
         catalog_data[train_name] = {}
         versions_data[train_name] = {}

--- a/catalog_reader/catalog.py
+++ b/catalog_reader/catalog.py
@@ -8,11 +8,15 @@ from .app_utils import get_default_questions_context
 from .train_utils import get_train_path, is_train_valid
 
 
-def app_details(apps: dict, location: str, questions_context: typing.Optional[dict], app_key: str) -> dict:
+def app_details(
+    apps: dict, location: str, questions_context: typing.Optional[dict], app_key: str, normalize_questions: bool = True,
+) -> dict:
     train = apps[app_key]
     app = app_key.removesuffix(f'_{train}')
     app_location = os.path.join(get_train_path(location), train, app)
-    return get_app_details(app_location, questions_context, {'retrieve_versions': True})
+    return get_app_details(
+        app_location, questions_context, {'retrieve_versions': True, 'normalize_questions': normalize_questions},
+    )
 
 
 def retrieve_train_names(location: str, all_trains=True, trains_filter=None) -> list:
@@ -37,8 +41,8 @@ def get_apps_in_trains(trains_to_traverse: list, catalog_location: str) -> dict:
 
 
 def retrieve_trains_data(
-    apps: dict, catalog_location: str, preferred_trains: list,
-    trains_to_traverse: list, job: typing.Any = None, questions_context: typing.Optional[dict] = None
+    apps: dict, catalog_location: str, preferred_trains: list, trains_to_traverse: list, job: typing.Any = None,
+    questions_context: typing.Optional[dict] = None, normalize_questions: bool = True,
 ) -> typing.Tuple[dict, set]:
     questions_context = questions_context or get_default_questions_context()
     trains = {

--- a/catalog_reader/catalog.py
+++ b/catalog_reader/catalog.py
@@ -54,7 +54,9 @@ def retrieve_trains_data(
     total_apps = len(apps)
     with concurrent.futures.ProcessPoolExecutor(max_workers=(5 if total_apps > 10 else 2)) as exc:
         for index, result in enumerate(zip(apps, exc.map(
-            functools.partial(app_details, apps, catalog_location, questions_context),
+            functools.partial(
+                app_details, apps, catalog_location, questions_context, normalize_questions=normalize_questions
+            ),
             apps, chunksize=(10 if total_apps > 10 else 5)
         ))):
             app_key = result[0]


### PR DESCRIPTION
## Problem
Currently, catalog updates are generating app caches with normalized question schemas. This normalization is not needed in the cache as it increases the size of the cache file and is totally irrelevant and redundant.

## Solution
Make changes to avoid normalizing the question schema while generating app versions cache files.
