### PR TITLE
NAS-130250 / 24.10 / Validate k8s to docker migration file

### DIFF
--- a/apps_validation/validate_app_version.py
+++ b/apps_validation/validate_app_version.py
@@ -15,6 +15,7 @@ from catalog_reader.questions_util import CUSTOM_PORTALS_KEY
 from .app_version import validate_app_version_file
 from .ix_values import validate_ix_values_schema
 from .json_schema_utils import VERSION_VALIDATION_SCHEMA
+from .validate_k8s_to_docker_migration import validate_k8s_to_docker_migrations
 from .validate_questions import validate_questions_yaml
 from .validate_templates import validate_templates
 
@@ -89,6 +90,9 @@ def validate_catalog_item_version(
             except ValidationErrors as v:
                 verrors.extend(v)
 
+    validate_k8s_to_docker_migrations(
+        verrors, os.path.join(version_path, 'migrations'), f'{schema}.migrations.migrate_from_kubernetes'
+    )
     # validate_app_migrations(verrors, version_path, f'{schema}.app_migrations')
     # FIXME: Add validation for app migrations
 

--- a/apps_validation/validate_k8s_to_docker_migration.py
+++ b/apps_validation/validate_k8s_to_docker_migration.py
@@ -1,0 +1,15 @@
+import contextlib
+import os.path
+
+from apps_exceptions import ValidationErrors
+
+
+def validate_k8s_to_docker_migrations(verrors: ValidationErrors, app_migration_path: str, schema: str):
+    file_to_check_path = os.path.join(app_migration_path, 'migrate_from_kubernetes')
+    with contextlib.suppress(FileNotFoundError):
+        with open(file_to_check_path, 'r') as r:
+            if not r.readline().startswith('#!'):
+                verrors.add(schema, 'Migration file should start with shebang line')
+
+        if not os.access(file_to_check_path, os.X_OK):
+            verrors.add(schema, 'Migration file is not executable')


### PR DESCRIPTION
## Problem
Kubernetes to Docker migration validation is not currently included in app_validation. The migration script must contain a shebang at the start and must be executable.

## Solution
Add validation for the Kubernetes to Docker migration file at the app level to ensure the migration file is executable and contains a shebang at the start.