### PR TITLE
NAS-130449 / 24.10 / Improve validation for apps

### DIFF
--- a/apps_ci/scripts/catalog_update.py
+++ b/apps_ci/scripts/catalog_update.py
@@ -50,7 +50,7 @@ def validate_train_data(train_data):
     except (json.JSONDecodeError, JsonValidationError) as e:
         verrors.add(
             'catalog_json',
-            f'Failed to validate contents of train data ({".".join(list(e.path))}): {e!r}'
+            f'Failed to validate contents of train data ({".".join([str(p) for p in e.path])}): {e!r}'
         )
     verrors.check()
 

--- a/apps_validation/json_schema_utils.py
+++ b/apps_validation/json_schema_utils.py
@@ -1,3 +1,22 @@
+APP_ITEM_JSON_SCHEMA = {
+    'type': 'object',
+    'properties': {
+        'categories': {
+            'type': 'array',
+            'items': {'type': 'string'},
+        },
+        'tags': {
+            'type': 'array',
+            'items': {'type': 'string'},
+        },
+        'screenshots': {
+            'type': 'array',
+            'items': {'type': 'string'},
+        },
+        'icon_url': {'type': 'string'},
+    },
+    'required': ['categories'],
+}
 APP_METADATA_JSON_SCHEMA = {
     'type': 'object',
     'properties': {
@@ -78,6 +97,14 @@ APP_METADATA_JSON_SCHEMA = {
                 },
                 'required': ['description', 'host_path'],
             },
+        },
+        'screenshots': {
+            'type': 'array',
+            'items': {'type': 'string'},
+        },
+        'categories': {
+            'type': 'array',
+            'items': {'type': 'string'},
         },
     },
     'required': [


### PR DESCRIPTION
## Problem

Having `screenshots/categories` keys in app's `app.yaml` is not a requirement but if they were added by app dev, we were not validating them. In this case misconfigured values for them have been added which is causing CI to fail and apps_validation should be catching this sooner.

## Solution

Properly make sure the app being validated in question is validated properly for these extra keys as well.