### PR TITLE
NAS-130493 / 24.10 / Provide min/max for port ref

### DIFF
--- a/catalog_reader/app_utils.py
+++ b/catalog_reader/app_utils.py
@@ -36,7 +36,6 @@ def get_default_questions_context() -> dict:
         'certificates': [],
         'certificate_authorities': [],
         'system.general.config': {'timezone': 'America/Los_Angeles'},
-        'unused_ports': [i for i in range(1025, 65535)],
         'gpu_choices': {}
     }
 

--- a/catalog_reader/questions.py
+++ b/catalog_reader/questions.py
@@ -126,11 +126,10 @@ def normalize_question(question: dict, version_data: dict, context: dict) -> Non
                 for i in context['certificate_authorities']
             ]
         elif ref == 'definitions/port':
-            data['enum'] = [{'value': None, 'description': 'No Port Selected'}] if schema.get('null') else []
-            data['enum'] += [
-                {'value': i, 'description': f'{i!r} Port'}
-                for i in context['unused_ports']
-            ]
+            data.update({
+                'min': 1,
+                'max': 65534,
+            })
         elif ref == 'normalize/acl':
             data['attrs'] = ACL_QUESTION
         elif ref == 'normalize/ix_volume':

--- a/catalog_reader/questions.py
+++ b/catalog_reader/questions.py
@@ -128,7 +128,7 @@ def normalize_question(question: dict, version_data: dict, context: dict) -> Non
         elif ref == 'definitions/port':
             data.update({
                 'min': 1,
-                'max': 65534,
+                'max': 65535,
             })
         elif ref == 'normalize/acl':
             data['attrs'] = ACL_QUESTION


### PR DESCRIPTION
This commit adds changes to provide min/max for port ref and no longer populates an enum.