### PR TITLE
produce cleaner markdown from readme

### DIFF
--- a/catalog_reader/app.py
+++ b/catalog_reader/app.py
@@ -152,15 +152,17 @@ def get_app_version_details(
 ) -> dict:
     options = options or {}
     version_data = {'location': version_path, 'required_features': set()}
-    for key, filename, parser in (
-        ('app_metadata', 'app.yaml', yaml.safe_load),
-        ('schema', 'questions.yaml', yaml.safe_load),
-        ('readme', 'README.md', markdown.markdown),
-        ('changelog', 'CHANGELOG.md', markdown.markdown),
+    for key, filename, parser, post_processor in (
+        ("app_metadata", "app.yaml", yaml.safe_load, None),
+        ("schema", "questions.yaml", yaml.safe_load, None),
+        ("readme", "README.md", markdown.markdown, lambda x: x.replace('\n', ' ')),
+        ("changelog", "CHANGELOG.md", markdown.markdown, None),
     ):
         if os.path.exists(os.path.join(version_path, filename)):
             with open(os.path.join(version_path, filename), 'r') as f:
                 version_data[key] = parser(f.read())
+                if post_processor:
+                    version_data[key] = post_processor(version_data[key])
         else:
             version_data[key] = None
 

--- a/catalog_reader/app.py
+++ b/catalog_reader/app.py
@@ -146,6 +146,8 @@ def get_app_details_impl(
 
     return item_data
 
+def new_line_to_space(text: str) -> str:
+    return text.replace('\n', ' ')
 
 def get_app_version_details(
     version_path: str, questions_context: typing.Optional[dict], options: typing.Optional[dict] = None
@@ -155,8 +157,8 @@ def get_app_version_details(
     for key, filename, parser, post_processor in (
         ("app_metadata", "app.yaml", yaml.safe_load, None),
         ("schema", "questions.yaml", yaml.safe_load, None),
-        ("readme", "README.md", markdown.markdown, lambda x: x.replace('\n', ' ')),
-        ("changelog", "CHANGELOG.md", markdown.markdown, None),
+        ("readme", "README.md", markdown.markdown, new_line_to_space),
+        ("changelog", "CHANGELOG.md", markdown.markdown, new_line_to_space),
     ):
         if os.path.exists(os.path.join(version_path, filename)):
             with open(os.path.join(version_path, filename), 'r') as f:

--- a/catalog_reader/app.py
+++ b/catalog_reader/app.py
@@ -146,8 +146,10 @@ def get_app_details_impl(
 
     return item_data
 
+
 def new_line_to_space(text: str) -> str:
     return text.replace('\n', ' ')
+
 
 def get_app_version_details(
     version_path: str, questions_context: typing.Optional[dict], options: typing.Optional[dict] = None
@@ -155,10 +157,10 @@ def get_app_version_details(
     options = options or {}
     version_data = {'location': version_path, 'required_features': set()}
     for key, filename, parser, post_processor in (
-        ("app_metadata", "app.yaml", yaml.safe_load, None),
-        ("schema", "questions.yaml", yaml.safe_load, None),
-        ("readme", "README.md", markdown.markdown, new_line_to_space),
-        ("changelog", "CHANGELOG.md", markdown.markdown, new_line_to_space),
+        ('app_metadata', 'app.yaml', yaml.safe_load, None),
+        ('schema', 'questions.yaml', yaml.safe_load, None),
+        ('readme', 'README.md', markdown.markdown, new_line_to_space),
+        ('changelog', 'CHANGELOG.md', markdown.markdown, new_line_to_space),
     ):
         if os.path.exists(os.path.join(version_path, filename)):
             with open(os.path.join(version_path, filename), 'r') as f:


### PR DESCRIPTION
Problem:

Markdown (and html) ignores single new lines.
To make it easier to layout long paragraphs in multiple lines
But when we convert `md` to `html` and them to `json`, those new lines are encoded in to the string and UI will actually render the new line.

If we take the output `markdown.markdown` and directly write it to `html`, it will display correctly (ignoring single new lines).
But because we then place it in a `json` which encodes the new lines in, then the output displays the new lines


Solution:

Replace the `\n` to ` `. This makes the UI render correctly the README, without developer having to constantly think how to write the readme files.


More context:
https://ixsystems.atlassian.net/jira/software/c/projects/TNCHARTS/issues/TNCHARTS-1305
