### PR TITLE
ci: make bump optional

### DIFF
--- a/apps_ci/scripts/bump_version.py
+++ b/apps_ci/scripts/bump_version.py
@@ -24,11 +24,12 @@ def update_app_version(app_path: str, bump_type: str, dep_name: str, dep_version
     with open(str(app_metadata_file), 'r') as f:
         app_config = yaml.safe_load(f.read())
 
-    old_version = app_config['version']
-    app_config['version'] = bump_version(old_version, bump_type)
     if dep_name and dep_version and is_main_dep(app_dir, dep_name):
         app_config['app_version'] = dep_version
-    rename_versioned_dir(old_version, app_config['version'], app_dir.parent.name, app_dir)
+    if bump_type:
+        old_version = app_config['version']
+        app_config['version'] = bump_version(old_version, bump_type)
+        rename_versioned_dir(old_version, app_config['version'], app_dir.parent.name, app_dir)
 
     with open(str(app_metadata_file), 'w') as f:
         f.write(yaml.safe_dump(app_config))

--- a/apps_ci/scripts/bump_version.py
+++ b/apps_ci/scripts/bump_version.py
@@ -24,19 +24,20 @@ def update_app_version(app_path: str, bump_type: str, dep_name: str, dep_version
     with open(str(app_metadata_file), 'r') as f:
         app_config = yaml.safe_load(f.read())
 
+    msg = ''
     if dep_name and dep_version and is_main_dep(app_dir, dep_name):
         app_config['app_version'] = dep_version
+        msg += f', set app_version to {dep_version!r}'
     if bump_type:
         old_version = app_config['version']
         app_config['version'] = bump_version(old_version, bump_type)
         rename_versioned_dir(old_version, app_config['version'], app_dir.parent.name, app_dir)
+        msg += f' and bumped version from {old_version!r} to {app_config["version"]!r}'
 
     with open(str(app_metadata_file), 'w') as f:
         f.write(yaml.safe_dump(app_config))
 
-    print(
-        f'[\033[92mOK\x1B[0m]\tUpdated app {app_dir.name!r} version from {old_version!r} to {app_config["version"]!r}'
-    )
+    print(f'[\033[92mOK\x1B[0m]\tUpdated app {app_dir.name!r}' + msg)
 
 
 def main():

--- a/apps_ci/version_bump.py
+++ b/apps_ci/version_bump.py
@@ -4,7 +4,7 @@ from apps_exceptions import AppDoesNotExist, ValidationErrors
 
 
 def map_renovate_bump_type(bump: str) -> str:
-    return bump if bump in ('patch', 'minor', 'major') else 'patch'
+    return bump if bump in ('patch', 'minor', 'major', '') else 'patch'
 
 
 def is_valid_version(version: str) -> bool:


### PR DESCRIPTION
Makes bumping version in CI optional.

Reasoning is that renovate calls this script on each dep update.
For example if an app have multiple containers, it will call it for each one of them.
That by itself is not an issue as wrap it in a bash script and call it once.
https://github.com/truenas/apps/blob/18c3dbfaf58341166c599b578ecf03ff4bc71d09/.github/scripts/renovate_bump.sh#L23-L25

However that means that if renovate calls the script FIRST for a container that is not the "main" container.
The app_version will never be bumped.

Solution is to call this script on every container, but only bump once.

This is paired with https://github.com/truenas/apps/pull/410