### PR TITLE
NAS-130790 / 25.04 / Validate default values exist in the enum specified in the schema

### DIFF
--- a/apps_schema/attrs/base.py
+++ b/apps_schema/attrs/base.py
@@ -71,6 +71,11 @@ class BaseSchema(metaclass=SchemaMeta):
                 except ValidationErrors as e:
                     verrors.extend(e)
 
+        if 'default' in self._schema_data and 'enum' in self._schema_data:
+            enum_values = [enum['value'] for enum in self._schema_data['enum']]
+            if self._schema_data['default'] not in enum_values:
+                verrors.add(f'{schema}.default', 'Default value is not in enum list')
+
         verrors.check()
 
     def json_schema(self):


### PR DESCRIPTION
## Problem

We are missing validation in the case when default values are not present in the enum options.

## Solution

Implement validation to ensure that default values are included within the enum options.
