### PR TITLE
NAS-133204 / 25.04 / fix, simplify, and speed-up render.py

### DIFF
--- a/catalog_templating/render.py
+++ b/catalog_templating/render.py
@@ -2,9 +2,7 @@ import collections
 import contextlib
 import importlib
 import os
-import pathlib
 import shutil
-import typing
 
 from jinja2 import Environment, FileSystemLoader
 
@@ -19,21 +17,20 @@ def render_templates(app_version_path: str, test_values: dict) -> dict:
         raise ValidationError('app_version_path', 'Unable to retrieve app metadata from specified app version path')
 
     template_path = os.path.join(app_version_path, 'templates')
-    if not pathlib.Path(os.path.join(template_path, 'library')).is_dir():
+    if not os.path.isdir(os.path.join(template_path, 'library')):
         return {}
 
     template_libs = import_library(os.path.join(template_path, 'library'), app_details)
     file_loader = FileSystemLoader(template_path)
     env = Environment(loader=file_loader, extensions=["jinja2.ext.do", "jinja2.ext.loopcontrols", "jinja2.ext.debug"])
     rendered_templates = {}
-    for to_render_file in filter(
-        lambda f: f.is_file() and f.name.endswith('.yaml'), pathlib.Path(template_path).iterdir()
-    ):
-        # TODO: Let's look to adding dynamic filter support in the future
-        # env.filters['make_capital'] = lambda st: st.upper()
-        rendered_templates[to_render_file.name] = env.get_template(
-            to_render_file.name
-        ).render({'ix_lib': template_libs, 'values': test_values})
+    with os.scandir(template_path) as sdir:
+        for i in filter(lambda x: x.is_file() and i.name.endswith('.yaml'), sdir):
+            # TODO: Let's look to adding dynamic filter support in the future
+            # env.filters['make_capital'] = lambda st: st.upper()
+            rendered_templates[i.name] = env.get_template(i.name).render(
+                {'ix_lib': template_libs, 'values': test_values}
+            )
 
     return rendered_templates
 
@@ -47,10 +44,10 @@ def import_library(library_path: str, app_config) -> dict:
         get_app_library_dir_name_from_version(app_config['version'])
     )
     additional_package_syspath = []
-    if app_config['lib_version'] and pathlib.Path(global_base_lib).is_dir():
+    if app_config['lib_version'] and os.path.isdir(global_base_lib):
         modules_context['base'] = import_app_modules(global_base_lib, os.path.basename(global_base_lib))  # base_v1_0_0
         additional_package_syspath.append(global_base_lib)
-    if pathlib.Path(app_lib).is_dir():
+    if os.path.isdir(app_lib):
         modules_context[app_config['train']] = {
             app_config['name']: import_app_modules(
                 app_lib, os.path.basename(app_lib), additional_package_syspath
@@ -61,7 +58,9 @@ def import_library(library_path: str, app_config) -> dict:
 
 
 def import_app_modules(
-    modules_path: str, parent_module_name: str, additional_package_syspath: typing.Optional[list] = None
+    modules_path: str,
+    parent_module_name: str,
+    additional_package_syspath: list | None = None
 ) -> dict:
 
     def import_module_context(module_name, file_path):
@@ -82,13 +81,12 @@ def import_app_modules(
     sub_modules_context = {}
     try:
         importlib.sys.path.extend([os.path.dirname(entry) for entry in additional_package_syspath])
-        for sub_modules_file in filter(
-            lambda p: os.path.isfile(os.path.join(modules_path, p)) and p.endswith('.py'), os.listdir(modules_path)
-        ):
-            sub_modules = sub_modules_file.removesuffix('.py')
-            sub_modules_context[sub_modules] = import_module_context(
-                f'{parent_module_name}.{sub_modules}', os.path.join(modules_path, sub_modules_file)
-            )
+        with os.scandir(modules_path) as sdir:
+            for i in filter(lambda x: x.is_file() and x.name.endswith('.py'), sdir):
+                sub_modules = i.name.removesuffix('.py')
+                sub_modules_context[sub_modules] = import_module_context(
+                    f'{parent_module_name}.{sub_modules}', os.path.join(modules_path, i.name)
+                )
     finally:
         for entry in additional_package_syspath:
             with contextlib.suppress(ValueError):


### PR DESCRIPTION
Using `os.listdir`, `pathlib.Path.iterdir`, `os.path.isfile` and `pathlib.Path.is_file` in the same file is strange and inconsistent. Simplify the for loops and use the much more performant `os.scandir` when iterating directories.