### PR TITLE
Fix dockerfile for apps validation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,16 +2,6 @@ FROM ghcr.io/truenas/middleware:master
 
 RUN /usr/bin/install-dev-tools
 
-RUN apt-get install -y \
-      debhelper-compat \
-      dh-python \
-      python3-dev \
-      python3-setuptools \
-      devscripts \
-      python3-jsonschema \
-      python3-semantic-version \
-      python3-yaml
-
 ENV PYTHONUNBUFFERED 1
 ENV WORK_DIR /app
 RUN mkdir -p ${WORK_DIR}


### PR DESCRIPTION
## Context

We are unnecessarily installing different apt packages which are already included in middleware base image and we are seeing problems with version dependency issues which we have no need to dive into as these packages are already available.