### PR TITLE
NAS-133964 / 25.10 / Add chart_metadata to generated app versions file

### DIFF
--- a/apps_validation/json_schema_utils.py
+++ b/apps_validation/json_schema_utils.py
@@ -319,6 +319,7 @@ VERSION_VALIDATION_SCHEMA = {
                     'pattern': '[0-9]+.[0-9]+.[0-9]+'
                 },
                 'app_metadata': APP_METADATA_JSON_SCHEMA,
+                'chart_metadata': APP_METADATA_JSON_SCHEMA,
                 'readme': {'type': ['string', 'null']},
                 'changelog': {'type': ['string', 'null']},
                 'schema': {

--- a/catalog_reader/app.py
+++ b/catalog_reader/app.py
@@ -191,6 +191,7 @@ def get_app_version_details(
     version_data.update({
         'human_version': get_human_version(app_metadata['app_version'], app_metadata['version']),
         'version': app_metadata['version'],
+        'chart_metadata': app_metadata,
     }) if app_metadata else {}
 
     return version_data


### PR DESCRIPTION
## Context

We have `chart_metadata` key being used to determine min/max scale version check on apps and as we are moving on to adding migrations which will only work in FT, we want to make sure users in EE are not able to consume these versions of the apps as migrations won't run in EE. 

So temporarily we are adding `chart_metadata` key there so anybody in EE trying to upgrade to these app versions which require migrations to function, has no issues and a nice error is displayed to them.