### PR TITLE
NAS-133957 / 25.10 / Remove certificate authority ref from apps validation

### DIFF
--- a/apps_schema/features/certificate.py
+++ b/apps_schema/features/certificate.py
@@ -7,9 +7,3 @@ class CertificateFeature(BaseFeature):
 
     NAME = 'definitions/certificate'
     VALID_SCHEMAS = [IntegerSchema]
-
-
-class CertificateAuthorityFeature(BaseFeature):
-
-    NAME = 'definitions/certificate_authority'
-    VALID_SCHEMAS = [IntegerSchema]

--- a/catalog_reader/pytest/unit/test_normalize_questions.py
+++ b/catalog_reader/pytest/unit/test_normalize_questions.py
@@ -383,35 +383,6 @@ GPU_DETAIL = [entry for entry in GPU_CHOICES if entry['gpu_details']['available_
             'schema': {
                 'type': 'string',
                 'hidden': True,
-                '$ref': ['definitions/certificate_authority'],
-            }
-        },
-        {
-            'variable': 'datasetName',
-            'label': 'Plots Volume Name',
-            'schema': {
-                'type': 'string',
-                'hidden': True,
-                '$ref': ['definitions/certificate_authority'],
-                'enum': [
-                    {'value': None, 'description': 'No Certificate Authority'},
-                    {'value': None, 'description': 'No Certificate Authority'}
-                ],
-                'default': None,
-                'null': True
-            }
-        },
-        {
-            'certificate_authorities': [],
-        }
-    ),
-    (
-        {
-            'variable': 'datasetName',
-            'label': 'Plots Volume Name',
-            'schema': {
-                'type': 'string',
-                'hidden': True,
                 '$ref': ['definitions/port'],
             }
         },

--- a/catalog_reader/questions.py
+++ b/catalog_reader/questions.py
@@ -122,7 +122,7 @@ def normalize_question(question: dict, version_data: dict, context: dict) -> Non
                 'default': '0.0.0.0',
                 'enum': [{'value': i, 'description': f'{i!r} IP Address'} for i in context['ip_choices']],
             })
-        elif ref in ('definitions/certificate', 'definitions/certificate_authority'):
+        elif ref == 'definitions/certificate':
             get_cert_ca_options(schema, data, {'value': None, 'description': 'No Certificate'})
             data['enum'] += [
                 {'value': i['id'], 'description': f'{i["name"]!r} Certificate'}

--- a/catalog_reader/questions.py
+++ b/catalog_reader/questions.py
@@ -122,17 +122,11 @@ def normalize_question(question: dict, version_data: dict, context: dict) -> Non
                 'default': '0.0.0.0',
                 'enum': [{'value': i, 'description': f'{i!r} IP Address'} for i in context['ip_choices']],
             })
-        elif ref == 'definitions/certificate':
+        elif ref in ('definitions/certificate', 'definitions/certificate_authority'):
             get_cert_ca_options(schema, data, {'value': None, 'description': 'No Certificate'})
             data['enum'] += [
                 {'value': i['id'], 'description': f'{i["name"]!r} Certificate'}
                 for i in context['certificates']
-            ]
-        elif ref == 'definitions/certificate_authority':
-            get_cert_ca_options(schema, data, {'value': None, 'description': 'No Certificate Authority'})
-            data['enum'] += [{'value': None, 'description': 'No Certificate Authority'}] + [
-                {'value': i['id'], 'description': f'{i["name"]!r} Certificate Authority'}
-                for i in context['certificate_authorities']
             ]
         elif ref == 'definitions/port':
             data.update({


### PR DESCRIPTION
This PR adds changes to remove `certificate_authorities` ref from apps validation, we would be making relevant changes in middleware as well in a different PR (same ticket, so these are merged together). This has never been used in our new apps implementation and as we are removing CA plugin, we are removing the support for the ref as well.