### PR TITLE
Add extra fields in annotations

### DIFF
--- a/apps_ci/pytest/unit/test_update_catalog_file.py
+++ b/apps_ci/pytest/unit/test_update_catalog_file.py
@@ -69,6 +69,7 @@ from apps_exceptions import ValidationErrors
                                 'train': 'stable',
                                 'version': '1.0.1',
                                 'app_version': '1.0.1',
+                                'date_added': '2025-04-08',
                                 'title': 'chia',
                                 'description': 'desc',
                                 'home': 'None',

--- a/apps_ci/pytest/unit/test_update_catalog_file.py
+++ b/apps_ci/pytest/unit/test_update_catalog_file.py
@@ -16,6 +16,7 @@ from apps_exceptions import ValidationErrors
                     'healthy': True,
                     'healthy_error': None,
                     'last_update': '2024-10-01 14:30:00',
+                    'date_added': '2025-04-08',
                     'recommended': [],
                     'latest_version': '1.2.0',
                     'latest_app_version': '1.2.0',
@@ -61,6 +62,7 @@ from apps_exceptions import ValidationErrors
                             'readme': None,
                             'changelog': None,
                             'last_update': '1200-20-00 00:00:00',
+                            'date_added': '2025-04-08',
                             'maintainers': {},
                             'app_metadata': {
                                 'name': 'chia',

--- a/apps_ci/pytest/unit/test_update_catalog_file.py
+++ b/apps_ci/pytest/unit/test_update_catalog_file.py
@@ -103,6 +103,7 @@ from apps_exceptions import ValidationErrors
                     'healthy': True,
                     'healthy_error': None,
                     'last_update': '2024-10-01 14:30:00',
+                    'date_added': '2025-04-08',
                     'recommended': [],
                 },
             }

--- a/apps_validation/json_schema_utils.py
+++ b/apps_validation/json_schema_utils.py
@@ -117,6 +117,7 @@ APP_METADATA_JSON_SCHEMA = {
     'required': [
         'name', 'train', 'version', 'app_version', 'title', 'description', 'home',
         'sources', 'maintainers', 'run_as_context', 'capabilities', 'host_mounts',
+        'date_added',
     ],
     'if': {
         'properties': {

--- a/apps_validation/json_schema_utils.py
+++ b/apps_validation/json_schema_utils.py
@@ -52,14 +52,14 @@ APP_METADATA_JSON_SCHEMA = {
         'train': {'type': 'string'},
         'description': {'type': 'string'},
         'home': {'type': 'string'},
+        'chagelog_url': {'type': 'string'},
+        'date_added': {'type': 'string'},
         'app_version': {'type': 'string'},
         'annotations': {
             'type': 'object',
             'properties': {
                 'min_scale_version': {'type': 'string'},
                 'max_scale_version': {'type': 'string'},
-                'chagelog_url': {'type': 'string'},
-                'date_added': {'type': 'string'},
             },
         },
         'title': {'type': 'string'},

--- a/apps_validation/json_schema_utils.py
+++ b/apps_validation/json_schema_utils.py
@@ -53,7 +53,10 @@ APP_METADATA_JSON_SCHEMA = {
         'description': {'type': 'string'},
         'home': {'type': 'string'},
         'chagelog_url': {'type': 'string'},
-        'date_added': {'type': 'string'},
+        'date_added': {
+            'type': 'string',
+            'pattern': '20[0-9][0-9]-[0-9][1-9]-[0-9][1-9]',
+        },
         'app_version': {'type': 'string'},
         'annotations': {
             'type': 'object',

--- a/apps_validation/json_schema_utils.py
+++ b/apps_validation/json_schema_utils.py
@@ -58,6 +58,8 @@ APP_METADATA_JSON_SCHEMA = {
             'properties': {
                 'min_scale_version': {'type': 'string'},
                 'max_scale_version': {'type': 'string'},
+                'chagelog_url': {'type': 'string'},
+                'date_added': {'type': 'string'},
             },
         },
         'title': {'type': 'string'},

--- a/apps_validation/pytest/unit/test_app_validate.py
+++ b/apps_validation/pytest/unit/test_app_validate.py
@@ -314,6 +314,7 @@ def test_validate_catalog_item(mocker, catalog_path, test_yaml, train, item_yaml
         name: storj
         version: 1.0.4
         train: stable
+        date_added: '2025-04-08'
         app_version: 1.0.0.8395
         title: storj
         description: Test description
@@ -337,6 +338,7 @@ def test_validate_catalog_item(mocker, catalog_path, test_yaml, train, item_yaml
         name: storj
         version: 1.0.4
         train: stable
+        date_added: '2025-04-08'
         app_version: 1.0.0.8395
         title: storj
         description: Test description
@@ -360,6 +362,7 @@ def test_validate_catalog_item(mocker, catalog_path, test_yaml, train, item_yaml
         name: storj
         version: 1.0.4
         train: stable
+        date_added: '2025-04-08'
         app_version: 1.0.0.8395
         title: storj
         description: Test description


### PR DESCRIPTION
Adds 2 fields.
- `changelog_url`. Which will always be optional, as not upstreams have one.
- `date_added`: Which will hold the initial date an app is added. Useful in order to have a "recently added" section.