### PR TITLE
dont copy test-files in published apps

### DIFF
--- a/apps_ci/scripts/catalog_update.py
+++ b/apps_ci/scripts/catalog_update.py
@@ -117,7 +117,7 @@ def publish_updated_apps(catalog_path: str) -> None:
             publish_item_yaml_path = os.path.join(publish_app_path, 'item.yaml')
 
             shutil.copy(dev_item_yaml_path, publish_item_yaml_path)
-            shutil.copytree(dev_app_path, publish_app_version_path)
+            shutil.copytree(dev_app_path, publish_app_version_path, ignore=shutil.ignore_patterns('test_values'))
 
             for file_name in OPTIONAL_METADATA_FILES + REQUIRED_METADATA_FILES:
                 with contextlib.suppress(OSError):


### PR DESCRIPTION
Those files are only for "smoke" tests in CI/PRs. We shouldnt need those on published apps.
I only want @sonicaj to confirm that are not used on truenas systems to validate if the app is healthy.

---

On a separate PR, we can change how the hash is generated for library (ignoring the tests directory).
And also stop copying them on the published apps as well