### PR TITLE
Revert "dont copy test-files in published apps"

### DIFF
--- a/apps_ci/scripts/catalog_update.py
+++ b/apps_ci/scripts/catalog_update.py
@@ -117,7 +117,7 @@ def publish_updated_apps(catalog_path: str) -> None:
             publish_item_yaml_path = os.path.join(publish_app_path, 'item.yaml')
 
             shutil.copy(dev_item_yaml_path, publish_item_yaml_path)
-            shutil.copytree(dev_app_path, publish_app_version_path, ignore=shutil.ignore_patterns('test_values'))
+            shutil.copytree(dev_app_path, publish_app_version_path)
 
             for file_name in OPTIONAL_METADATA_FILES + REQUIRED_METADATA_FILES:
                 with contextlib.suppress(OSError):


### PR DESCRIPTION
Reverts truenas/apps_validation#73

Apparently we are re-validating that an app renders right before we update the catalog.
Reverting this to fix catalog, until we figure a better way

```
Entry: catalog_update.py (arg update) ->
Func chain:

update_catalog_file ->
get_trains ->
retrieve_trains_data ->
app_details ->
get_app_details ->
validate_catalog_item ->
validate_catalog_item_version ->
validate_templates ->
validate_template_rendering
```

FIxes https://github.com/truenas/apps/issues/2295
