### PR TITLE
Make sure we properly get last update of catalog app

### DIFF
--- a/catalog_reader/app.py
+++ b/catalog_reader/app.py
@@ -30,7 +30,6 @@ def get_app_details(
     item_data = get_app_details_base()
     item_data.update({
         'location': item_location,
-        'last_update': get_last_updated_date(catalog_path, item_location),
         'name': item,
         'title': item.capitalize(),
     })
@@ -83,6 +82,9 @@ def get_app_details(
             if not item_data['app_readme']:
                 item_data['app_readme'] = v['readme']
 
+    item_data['last_update'] = get_last_updated_date(
+        catalog_path, os.path.join(item_location, item_data['latest_version'])
+    )
     if unhealthy_versions:
         item_data['healthy_error'] = f'Errors were found with {", ".join(unhealthy_versions)} version(s)'
     else:

--- a/catalog_reader/app.py
+++ b/catalog_reader/app.py
@@ -30,6 +30,7 @@ def get_app_details(
     item_data = get_app_details_base()
     item_data.update({
         'location': item_location,
+        'last_update': get_last_updated_date(catalog_path, item_location),
         'name': item,
         'title': item.capitalize(),
     })

--- a/catalog_reader/pytest/unit/test_app_details.py
+++ b/catalog_reader/pytest/unit/test_app_details.py
@@ -28,17 +28,29 @@ QUESTION_CONTEXT = {
             'healthy_error': None,
             'home': None,
             'last_update': None,
-            'versions': {},
             'maintainers': [],
-            'latest_version': None,
-            'latest_app_version': None,
-            'latest_human_version': None,
+            'latest_version': '1.0.0',
+            'latest_app_version': '1.0.0',
+            'latest_human_version': '1.0.0',
             'recommended': False,
             'title': 'Chia',
             'description': None,
             'tags': [],
             'screenshots': [],
             'sources': [],
+            'versions': {
+                '1.0.0': {
+                    'healthy': True,
+                    'app_metadata': {
+                        'app_version': '1.0.0',
+                        'maintainers': [],
+                        'description': None,
+                        'home': None,
+                        'sources': []
+                    },
+                    'readme': None,
+                }
+            }
         }
     ),
     (
@@ -54,9 +66,9 @@ QUESTION_CONTEXT = {
             'home': None,
             'last_update': None,
             'maintainers': [],
-            'latest_version': None,
-            'latest_app_version': None,
-            'latest_human_version': None,
+            'latest_version': '1.0.0',
+            'latest_app_version': '1.0.0',
+            'latest_human_version': '1.0.0',
             'recommended': False,
             'title': 'Chia',
             'description': None,
@@ -68,7 +80,21 @@ QUESTION_CONTEXT = {
 ])
 def test_get_app_details(mocker, item_path, options, items_data):
     mocker.patch('catalog_reader.app.validate_catalog_item', return_value=None)
-    mocker.patch('catalog_reader.app.get_app_details_impl', return_value={})
+    mocker.patch('catalog_reader.app.get_app_details_impl', return_value={
+        'versions': {
+                '1.0.0': {
+                    'healthy': True,
+                    'app_metadata': {
+                        'app_version': '1.0.0',
+                        'maintainers': [],
+                        'description': None,
+                        'home': None,
+                        'sources': []
+                    },
+                    'readme': None,
+                }
+        }
+    })
     assert get_app_details(item_path, QUESTION_CONTEXT, options) == items_data
 
 


### PR DESCRIPTION
This PR adds changes to make sure we properly get last update value for an app. Currently what happened was that we were checking last update of the parent folder which actually got updated always when CI actions were executed. Instead what we should be doing is that we should get that from the latest version which has been updated.