### PR TITLE
make sure we update app version only when updating the "main" image

### DIFF
--- a/apps_ci/images_info.py
+++ b/apps_ci/images_info.py
@@ -32,7 +32,7 @@ def is_main_dep(app_dir: Path, dep_name: str, dep_version: str) -> bool:
     verrors.check()
     with open(ix_values, 'r') as f:
         ix_values_data = yaml.safe_load(f.read())
-        main_image = ix_values_data.get('image', {})
+        main_image = ix_values_data.get('images', {}).get('image', {})
         repo = main_image.get('repository')
         tag = main_image.get('tag')
         if repo == dep_name and tag == dep_version:

--- a/apps_ci/images_info.py
+++ b/apps_ci/images_info.py
@@ -19,7 +19,7 @@ images:
 """
 
 
-def is_main_dep(app_dir: Path, dep_name: str) -> bool:
+def is_main_dep(app_dir: Path, dep_name: str, dep_version: str) -> bool:
     if not app_dir.is_dir():
         raise AppDoesNotExist(app_dir)
     if not dep_name:
@@ -32,7 +32,10 @@ def is_main_dep(app_dir: Path, dep_name: str) -> bool:
     verrors.check()
     with open(ix_values, 'r') as f:
         ix_values_data = yaml.safe_load(f.read())
-        if ix_values_data.get('images', {}).get('image', {}).get('repository') == dep_name:
+        main_image = ix_values_data.get('image', {})
+        repo = main_image.get('repository')
+        tag = main_image.get('tag')
+        if repo == dep_name and tag == dep_version:
             return True
 
     return False

--- a/apps_ci/scripts/bump_version.py
+++ b/apps_ci/scripts/bump_version.py
@@ -25,7 +25,7 @@ def update_app_version(app_path: str, bump_type: str, dep_name: str, dep_version
         app_config = yaml.safe_load(f.read())
 
     msg = ''
-    if dep_name and dep_version and is_main_dep(app_dir, dep_name):
+    if dep_name and dep_version and is_main_dep(app_dir, dep_name, dep_version):
         app_config['app_version'] = dep_version
         msg += f', set app_version to {dep_version!r}'
     if bump_type:


### PR DESCRIPTION
Currently if renovate calls this script with dep_name `some_dep`.
And `some_dep` is used by the main image, we set the app version to the new dep_version.

However there are apps that we have images like this 
`some_dep` with tag `v###-full`
`some_dep` with tag `v###-nvidia`

Essentially same "dep" but different tags

So if renovate updates the nvidia image, the `app_version` will be set to `v###-nvidia`.
We don't want that.

This PR adds a check to make sure the new dep version also matches with the image to ensure it is really the "main" image