### PR TITLE
Allow updating library on a single app.

### DIFF
--- a/catalog_reader/scripts/apps_hashes.py
+++ b/catalog_reader/scripts/apps_hashes.py
@@ -85,9 +85,13 @@ def update_catalog_hashes(
             base_lib_name = get_base_library_dir_name_from_version(lib_version)
             app_lib_dir = app_dir / 'templates/library'
             app_lib_dir.mkdir(exist_ok=True, parents=True)
-            app_base_lib_dir = app_lib_dir / base_lib_name
-            shutil.rmtree(app_base_lib_dir.as_posix(), ignore_errors=True)
 
+            # Remove all old library versions
+            for old_lib_dir in app_lib_dir.iterdir():
+                if old_lib_dir.is_dir():
+                    shutil.rmtree(old_lib_dir.as_posix(), ignore_errors=True)
+
+            app_base_lib_dir = app_lib_dir / base_lib_name
             catalog_base_lib_dir_path = os.path.join(library_dir.as_posix(), lib_version)
             shutil.copytree(catalog_base_lib_dir_path, app_base_lib_dir.as_posix())
 

--- a/catalog_reader/scripts/apps_hashes.py
+++ b/catalog_reader/scripts/apps_hashes.py
@@ -45,11 +45,8 @@ def update_catalog_hashes(
         print('[\033[92mOK\x1B[0m]\tNo hashes found for library versions, skipping updating apps hashes')
         return
 
-    app_found = False
     is_single_app = train_name and app_name
     for train_dir in dev_directory.iterdir():
-        if is_single_app and app_found:
-            break
         if not train_dir.is_dir():
             continue
 
@@ -57,9 +54,6 @@ def update_catalog_hashes(
             continue
 
         for app_dir in train_dir.iterdir():
-            if is_single_app and app_found:
-                break
-
             if not app_dir.is_dir():
                 continue
 
@@ -108,9 +102,9 @@ def update_catalog_hashes(
             print(message)
 
             if is_single_app:
-                app_found = True
+                return
 
-    if is_single_app and not app_found:
+    if is_single_app:
         verrors.add('app', f'App {app_name!r} not found in train {train_name!r}')
         verrors.check()
 

--- a/catalog_reader/scripts/apps_hashes.py
+++ b/catalog_reader/scripts/apps_hashes.py
@@ -23,7 +23,7 @@ def update_catalog_hashes(
 
     verrors = ValidationErrors()
     if (train_name and not app_name) or (app_name and not train_name):
-        verrors.add('app_train', 'Both --train and --app must be specified together')
+        verrors.add('train_app_pair', 'Both --train and --app must be specified together')
 
     library_dir = pathlib.Path(get_library_path(catalog_path))
     if not library_dir.exists():
@@ -125,11 +125,11 @@ def main():
     )
     parser.add_argument(
         '--train', type=str, required=False,
-        help='Specify a train name to filter apps'
+        help='Specify a train name (must be used with --app)'
     )
     parser.add_argument(
         '--app', type=str, required=False,
-        help='Specify a single app name to update instead of updating all apps'
+        help='Specify a single app name to update (must be used with --train)'
     )
 
     args = parser.parse_args()

--- a/catalog_reader/scripts/apps_hashes.py
+++ b/catalog_reader/scripts/apps_hashes.py
@@ -45,8 +45,12 @@ def update_catalog_hashes(
         print('[\033[92mOK\x1B[0m]\tNo hashes found for library versions, skipping updating apps hashes')
         return
 
+    app_found = False
     is_single_app = train_name and app_name
     for train_dir in dev_directory.iterdir():
+        if is_single_app and app_found:
+            break
+
         if not train_dir.is_dir():
             continue
 
@@ -54,11 +58,17 @@ def update_catalog_hashes(
             continue
 
         for app_dir in train_dir.iterdir():
+            if is_single_app and app_found:
+                break
+
             if not app_dir.is_dir():
                 continue
 
             if is_single_app and app_dir.name != app_name:
                 continue
+
+            if is_single_app:
+                app_found = True
 
             app_metadata_file = app_dir / 'app.yaml'
             if not app_metadata_file.is_file():
@@ -101,10 +111,7 @@ def update_catalog_hashes(
                 message += f' and bumped version from {old_version!r} to {app_config["version"]!r}'
             print(message)
 
-            if is_single_app:
-                return
-
-    if is_single_app:
+    if is_single_app and not app_found:
         verrors.add('app', f'App {app_name!r} not found in train {train_name!r}')
         verrors.check()
 

--- a/catalog_reader/scripts/apps_hashes.py
+++ b/catalog_reader/scripts/apps_hashes.py
@@ -88,7 +88,7 @@ def update_catalog_hashes(
 
             # Remove all old library versions
             for old_lib_dir in app_lib_dir.iterdir():
-                if old_lib_dir.is_dir():
+                if old_lib_dir.is_dir() and old_lib_dir.name.startswith("base_"):
                     shutil.rmtree(old_lib_dir.as_posix(), ignore_errors=True)
 
             app_base_lib_dir = app_lib_dir / base_lib_name
@@ -110,7 +110,8 @@ def update_catalog_hashes(
             print(message)
 
     if is_single_app and not app_found:
-        print(f'[\033[91mERROR\x1B[0m]\tApp {app_name!r} not found in train {train_name!r}')
+        verrors.add('app', f'App {app_name!r} not found in train {train_name!r}')
+        verrors.check()
 
 
 def main():

--- a/catalog_reader/scripts/apps_hashes.py
+++ b/catalog_reader/scripts/apps_hashes.py
@@ -70,8 +70,6 @@ def update_catalog_hashes(
             if not app_metadata_file.is_file():
                 continue
 
-            app_found = True
-
             with open(str(app_metadata_file), 'r') as f:
                 app_config = yaml.safe_load(f.read())
 
@@ -108,6 +106,9 @@ def update_catalog_hashes(
             if bump_type:
                 message += f' and bumped version from {old_version!r} to {app_config["version"]!r}'
             print(message)
+
+            if is_single_app:
+                app_found = True
 
     if is_single_app and not app_found:
         verrors.add('app', f'App {app_name!r} not found in train {train_name!r}')


### PR DESCRIPTION
Currently, when running the hash generate it does so for all apps.
And if all the apps has the "latest" library set, it will take ~15-20s to complete.
But doing this for only a single app takes <2s.

This helps a lot when doing local dev or CI, as the lib update is part of the CI script I run to render the app.

---

Also cleans up older libraries, as we only use a single version per app.