### PR TITLE
trim spaces on rendered templates

### DIFF
--- a/catalog_templating/scripts/render_compose.py
+++ b/catalog_templating/scripts/render_compose.py
@@ -30,7 +30,7 @@ def write_template_yaml(app_path: str, rendered_templates: dict) -> None:
     for file_name, rendered_template in rendered_templates.items():
         with open(os.path.join(rendered_templates_path, file_name), 'w') as f:
             os.fchmod(f.fileno(), 0o600)
-            f.write(rendered_template)
+            f.write(rendered_template.strip() + '\n')
 
 
 def main():


### PR DESCRIPTION
Rendered templates usually contain many leading empty lines in most cases. (Due to jinja directives that dont produce actual output)
Even for debugging some times you have to scroll a lot to "get to the content".

This trims this empty space, while there, trims any trailing space as well

Related: https://github.com/truenas/apps/issues/4392#issuecomment-3921776730