### PR TITLE
NAS-140553 / 26.0.0-BETA.2 / Allow x-action-required in portals/notes schema (by sonicaj)

### DIFF
--- a/apps_validation/portals.py
+++ b/apps_validation/portals.py
@@ -5,10 +5,14 @@ from apps_exceptions import ValidationErrors
 
 IX_NOTES_KEY = 'x-notes'
 IX_PORTAL_KEY = 'x-portals'
+IX_ACTION_REQUIRED_KEY = 'x-action-required'
 VALIDATION_SCHEMA = {
     '$schema': 'https://json-schema.org/draft/2020-12/schema',
     'type': 'object',
     'properties': {
+        'x-action-required': {
+            'type': ['boolean', 'null'],
+        },
         'x-portals': {
             'type': 'array',
             'items': {


### PR DESCRIPTION
This commit adds changes to allow app devs to specify `x-action-required` in schema to notify the user if there are some actions which should be performed wrt the app.

Original PR: https://github.com/truenas/apps_validation/pull/93
